### PR TITLE
Add two-way binding to disabled property

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Example:
 
 The color property should be set and will be updated through Ember's two-way bindings.
 
+The disabled property (optional) can be toggled through Ember's two-way bindings.
+
 The following properties can be set to customize a particular color picker:
 
 * `allowEmpty` (default: `false`): whether or not the color value may be null.

--- a/addon/components/spectrum-color-picker.js
+++ b/addon/components/spectrum-color-picker.js
@@ -55,6 +55,10 @@ export default Ember.Component.extend({
     this.$().spectrum('set', this.get('color'));
   }),
 
+  updateDisabled: Ember.observer('disabled', function () {
+    this.$().spectrum(this.get('disabled') ? 'disable' : 'enable');
+  }),
+
   didInsertElement() {
     let palette = this.get('palette');
     let opts = {


### PR DESCRIPTION
The original jQuery Spectrum plugin (https://bgrins.github.io/spectrum/#options-disabled) allows you to toggle the disabled property, but the current master of ember-spectrum-color-picker does not allow two-way bindings to control this property. 

This PR adds an observer on the disabled property that uses the `disable` (https://bgrins.github.io/spectrum/#methods-disable) and `enable` (https://bgrins.github.io/spectrum/#methods-enable) functions on jQuery Spectrum to support two-way binding.