### PR TITLE
Fix moveFiresChange option preventing color update on picker close

### DIFF
--- a/addon/components/spectrum-color-picker.js
+++ b/addon/components/spectrum-color-picker.js
@@ -97,10 +97,10 @@ export default Ember.Component.extend({
       }
     };
 
+    opts.change = updateFunction;
+
     if (this.get('moveFiresChange')) {
       opts.move = updateFunction;
-    } else {
-      opts.change = updateFunction;
     }
 
     // Move Event


### PR DESCRIPTION
As of now, the `moveFiresChange` option allows the value to be updated in real time when the user clicks in the color picker. That being said, it actually prevents the value to be updated when clicking the "choose" button, meaning if you set `moveFiresChange` to `true`, manually type a value in the input and then click the "choose" button, the preview will be fine, but the underlying value won't be updated.

I moved the `opts.change` binding outside the else case so the color always gets updated when clicking the choose button, whether the `moveFiresChange` option is true or false.