### PR TITLE
avoid calling set on destroyed objects

### DIFF
--- a/addon/components/spectrum-color-picker.js
+++ b/addon/components/spectrum-color-picker.js
@@ -90,7 +90,9 @@ export default Ember.Component.extend({
       let color = newColor ? newColor.toString() : null;
       let onChange = self.get('onChange');
 
-      self.set('color', color);
+      if (!self.isDestroyed) {
+        self.set('color', color);
+      }
 
       if (onChange) {
         onChange(color);


### PR DESCRIPTION
Since the `updateFunction` will get called back asynchronously, this can happen even after the `self` object has been "destroyed". In this condition, Ember will raise an assertion error. I was seeing this a lot when I was running a test suite, although I've never seen it happen in an application.

This PR simply guards against calling set if the object is destroyed.