### PR TITLE
Fastboot compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
-
-    app.import('bower_components/spectrum/spectrum.js');
+    if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
+      app.import('bower_components/spectrum/spectrum.js');
+    }
     app.import('bower_components/spectrum/spectrum.css');
   }
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli": "2.6.1",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-fastboot": "1.0.0-beta.4",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",


### PR DESCRIPTION
Thanks for the addon!

jQuery doesn't work in node-land. Including scripts that assume it is loaded will cause crashing when server-side rendering.