### PR TITLE
Make asset path configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,26 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+
+var defaults = {
+  assetPath: 'bower_components/spectrum'
+};
+
 module.exports = {
   name: 'ember-spectrum-color-picker',
 
   included: function(app) {
     this._super.included(app);
 
+    var options = (app && app.project.config(app.env)['emberSpectrumColorPicker']) || {};
+
+    var assetPath = options.assetPath || defaults.assetPath;
+
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import('bower_components/spectrum/spectrum.js');
+      app.import(path.join(assetPath, 'spectrum.js'));
     }
 
-    app.import('bower_components/spectrum/spectrum.css');
+    app.import(path.join(assetPath, 'spectrum.css'));
   }
 };


### PR DESCRIPTION
This allows an application to get their spectrum assets from somewhere other than Bower. The asset can be specified in `config/environment.js`, for example:

    const ENV = {
        ...

        emberSpectrumColorPicker: {
            assetPath: 'vendor/spectrum'
        },

        ...
    }