### PR TITLE
Use better app lookup for compatibility in an engine

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,14 +16,15 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    var options = (app && app.project.config(app.env)['emberSpectrumColorPicker']) || {};
+    var target = this._findApp(app);
+    var options = (target && target.project.config(target.env)['emberSpectrumColorPicker']) || {};
 
     var assetPath = options.assetPath || defaults.assetPath;
 
-    app.import(path.join(assetPath, 'spectrum.js'));
+    target.import(path.join(assetPath, 'spectrum.js'));
 
     if (options.includeStyles) {
-      app.import(path.join(assetPath, 'spectrum.css'));
+      target.import(path.join(assetPath, 'spectrum.css'));
     }
   },
 
@@ -41,5 +42,20 @@ module.exports = {
     var spectrumTree = mergeTrees([spectrumJsTree, spectrumCssTree]);
 
     return vendorTree ? mergeTrees([vendorTree, spectrumTree]) : spectrumTree;
-  }
+  },
+
+  _findApp: function(hostApp) {
+    var app = this.app || hostApp;
+    var parent = this.parent;
+
+    while (parent.parent) {
+      if (parent.app) {
+        app = parent.app;
+        break;
+      }
+
+      parent = parent.parent;
+    }
+    return app;
+  },
 };


### PR DESCRIPTION
When using this addon in an engine (and possibly other contexts like nested addons or in-repo addons), you have to do a bit more work to dig through before you can `app.import` a dependency.

(The lookup code included is stolen from [ember-maybe-import-regenerator](https://github.com/machty/ember-maybe-import-regenerator/blob/master/index.js#L43).)